### PR TITLE
Properly handle protected endpoints with query strings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@ URL, the proxy will take care of the rest.
 Example nginx.conf would look like the following...
 
 ```
-location /secure {
-    auth_request /saml/status/group/uw_example_group;
+location / {
+    auth_request /saml/status/group/uw_it_all;
     auth_request_set $auth_user $upstream_http_x_saml_user;
+    error_page 401 = @login_required;
     proxy_set_header Remote-User $auth_user;
     proxy_pass http://secure:5000/;
 }
@@ -18,21 +19,23 @@ location /saml/ {
     proxy_set_header Host $http_host;
     proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Prefix /saml;
     proxy_set_header X-Saml-Entity-Id https://samldemo.iamdev.s.uw.edu/saml;
+    # acs - post-back url registered with the IdP.
     proxy_set_header X-Saml-Acs /saml/login;
     proxy_pass http://saml:5000/;
 }
 
-location @error401 {
-    return 302 https://$http_host/saml/login?url=$request_uri;
+location @login_required {
+    return 302 https://$http_host/saml/login$request_uri;
 }
 ```
+
+See the [example nginx config](test/nginx/server.conf) for more examples.
 
 ## SECRET_KEY
 
 This app wants an environment variable `SECRET_KEY`, which should be a secure,
 randomly-generated string. Otherwise, we generate one on the fly, which only
-works long as the app is running, and won't work in a distributed environment.
+works as long as the app is running, and won't work in a distributed environment.
 SECRET_KEY is used to sign cookies, so setting a new key effectively
 invalidates all existing sessions.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3'
+services:
+  saml:
+    build: .
+    image: nginx-saml-proxy
+    volumes:
+      - ./app.py:/app/app.py
+  nginx:
+    build: test/nginx
+    image: mynginx
+    ports: ["443:443"]
+    volumes:
+      - ./test/nginx/server.conf:/etc/nginx/conf.d/server.conf

--- a/test/nginx/Dockerfile
+++ b/test/nginx/Dockerfile
@@ -1,0 +1,17 @@
+FROM nginx as certbuilder
+
+RUN apt-get update && apt-get install -y ssl-cert && apt-get clean
+RUN mkdir /ssl && \
+    cp -p /etc/ssl/private/ssl-cert-snakeoil.key /ssl/key.pem && \
+    cp -p /etc/ssl/certs/ssl-cert-snakeoil.pem /ssl/cert.pem
+
+FROM nginx
+
+EXPOSE 80
+EXPOSE 443
+
+RUN rm /etc/nginx/conf.d/* && mkdir /static
+COPY server.conf /etc/nginx/conf.d/server.conf
+COPY --from=certbuilder /ssl /etc/nginx/ssl
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/test/nginx/server.conf
+++ b/test/nginx/server.conf
@@ -1,0 +1,33 @@
+server {
+  listen 443 ssl;
+  ssl_certificate /etc/nginx/ssl/cert.pem;
+  ssl_certificate_key /etc/nginx/ssl/key.pem;
+  root /usr/share/nginx/html;
+
+  # anyone with a UW NetID can access this
+  location / {
+    auth_request /saml/status;
+    auth_request_set $auth_user $upstream_http_x_saml_user;
+    error_page 401 = @login_required;
+  }
+
+  # user must be a member of uw_it_all
+  location /secure {
+      auth_request /saml/status/group/uw_it_all;
+      error_page 401 = @login_required;
+      alias /usr/share/nginx/html;
+  }
+
+  location /saml/ {
+    proxy_set_header Host $http_host;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Saml-Entity-Id https://samldemo.iamdev.s.uw.edu/saml;
+    proxy_set_header X-Saml-Acs /saml/login;
+    proxy_pass http://saml:5000/;
+  }
+
+  location @login_required {
+    return 302 https://$http_host/saml/login$request_uri;
+  }
+}


### PR DESCRIPTION
To facilitate nginx configuration, we've changed the redirect from
https://$http_host/saml/login?url=$request_uri to
https://$http_host/saml/login$request_uri. I erroneously thought $request_uri
would be encoded, but it wasn't. The old way created a potentially invalid uri.
The new way preserves the original url that we want to come back to.