### PR TITLE
Changed source image to python:3.7-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-slim
+FROM python:3.7-slim
 
 RUN apt-get update && \
     apt-get install -y libxmlsec1-dev build-essential libxmlsec1 libxmlsec1-openssl pkg-config && \


### PR DESCRIPTION
Since the release of Python 3.8, this will no longer successfully build using the python:3-slim tag. Using the more specific python:3.7-slim tag fixes the build issue. 

Python 3.7 has security support through June 2023