### PR TITLE
Migrate to gar

### DIFF
--- a/.github/workflows/publish-on-release.yaml
+++ b/.github/workflows/publish-on-release.yaml
@@ -7,13 +7,14 @@ name: Create and publish a Docker image on release
 on:
   push:
     branches: ['release']
+  workflow_dispatch:
 
 env:
-  REGISTRY: ghcr.io
+  REGISTRY: us-docker.pkg.dev/uwit-mci-iam/containers
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build-and-push-image-to-ghcr:
+  build-and-push-image-to-gar:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -21,22 +22,18 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Login to ghcr.io Container registry
-        # should this be pinned?
-        # https://github.com/docker/login-action
-        uses: docker/login-action@v2.1.0
+      - name: Auth to Cloud
+        uses: 'uwit-iam/action-auth-artifact-registry@main'
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GHCR_TOKEN }}
+          credentials: "${{ secrets.MCI_GCLOUD_AUTH_JSON }}"
 
       - name: Extract metadata (tags + labels) for Docker
         id: meta
         # should this be pinned?
         # https://github.com/docker/metadata-action
-        uses: docker/metadata-action@v4.4.0
+        uses: docker/metadata-action@v5.5.1
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 

--- a/.github/workflows/publish-on-release.yaml
+++ b/.github/workflows/publish-on-release.yaml
@@ -11,7 +11,7 @@ on:
 
 env:
   REGISTRY: us-docker.pkg.dev/uwit-mci-iam/containers
-  IMAGE_NAME: ${{ github.repository }}
+  OWNER_IMAGE: ${{ github.repository }}
 
 jobs:
   build-and-push-image-to-gar:
@@ -24,6 +24,12 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
+      - name: Compute repository name
+        id: image_name
+        run: |
+          # GH=uwit-iam/nginx-saml-proxy; echo ${GH#*/} returns "nginx-saml-proxy"
+          echo "IMAGE_NAME=${OWNER_IMAGE#*/}" >> $GITHUB_OUTPUT
+
       - name: Auth to Cloud
         uses: 'uwit-iam/action-auth-artifact-registry@main'
         with:
@@ -35,12 +41,12 @@ jobs:
         # https://github.com/docker/metadata-action
         uses: docker/metadata-action@v5.5.1
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ steps.image_name.outputs.IMAGE_NAME }}
 
       - name: Build and push Docker image
         # should this be pinned?
         # https://github.com/docker/build-push-action
-        uses: docker/build-push-action@v4.0.0
+        uses: docker/build-push-action@v6.7.0
         with:
           context: .
           push: true


### PR DESCRIPTION
nginx-saml-proxy is a core piece of the [example-flask-app](https://github.com/UWIT-IAM/example-flask-app) that several MCI apps are based on.

This successfully ran and pushed a new image to [our "containers" registry in GAR](https://console.cloud.google.com/artifacts/docker/uwit-mci-iam/us/containers/nginx-saml-proxy?project=uwit-mci-iam) in [this Action run](https://github.com/UWIT-IAM/nginx-saml-proxy/actions/runs/10930900107)

I haven't actually tested it live because I don't think there's anything about this that meaningfully impacts that.

It appears to me that the ghcr.io image wasn't even used as [gcp-k8 shows nginx-saml-proxy is a docker.io image](https://github.com/UWIT-IAM/gcp-k8/blob/main/prod/nginx-saml-proxy/helm-release.yml#L27) so I'll need to spin this up in dev and see if anything unfortunate happens...